### PR TITLE
chore(workflow): pre-v0.2 polish pass (closes #11)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,14 @@ jobs:
         with:
           skip-existing: true
 
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes
+
       - name: Open issue on failure
         if: failure()
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes
+          if gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
+            echo "Release ${{ github.ref_name }} already exists, skipping."
+          else
+            gh release create "${{ github.ref_name }}" \
+              --title "${{ github.ref_name }}" \
+              --generate-notes
+          fi
 
       - name: Open issue on failure
         if: failure()

--- a/.github/workflows/weekly-refresh.yml
+++ b/.github/workflows/weekly-refresh.yml
@@ -57,7 +57,10 @@ jobs:
             10000 \
             2>&1 | tee nemweb-mirror/download.log
           FAILED=$(grep -c "status=" nemweb-mirror/download.log || true)
-          TOTAL=$(grep -c "fetch\[" nemweb-mirror/download.log || true)
+          # EXT-3 split successful fetches into `fetch[` (content changed) and
+          # `fetch_noop[` (byte-identical, save_listing short-circuit). Both
+          # count as successful crawl attempts for block-check denominator.
+          TOTAL=$(grep -cE "fetch(_noop)?\[" nemweb-mirror/download.log || true)
           echo "failed=$FAILED" >> $GITHUB_OUTPUT
           echo "total=$TOTAL" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/weekly-refresh.yml
+++ b/.github/workflows/weekly-refresh.yml
@@ -46,7 +46,6 @@ jobs:
         run: |
           TS=$(date -u +%Y-%m-%dT%H:%M:%SZ)
           echo "LAST_CRAWL_ATTEMPTED_AT=$TS" >> $GITHUB_ENV
-          echo "ts=$TS" >> $GITHUB_OUTPUT
 
       - name: Crawl NEMWEB (policy-driven)
         id: crawl

--- a/scripts/audit_policy.py
+++ b/scripts/audit_policy.py
@@ -9,6 +9,16 @@ freshness_class. Findings:
 - reclassify_down: path classified `rolling` but fresh refetch HREFs are
   identical to cached. Candidate for demotion; weaker signal (AEMO may have
   paused publication temporarily), so reviewer decides per reading.
+- append_only_drift: path classified `append_only` but fresh refetch has
+  fewer HREFs than cached (removed > 0). The class guarantee is that files
+  only accumulate — any removal violates it. Reclassify to `rolling` or
+  investigate whether AEMO genuinely deleted something. Additions alone are
+  expected and do not trigger this finding.
+- parent_index_drift: path classified `parent_index` but the HREF set
+  changed in any direction (added + removed > 0). A parent index's children
+  set should be stable; any set-level change — new child, removed child, or
+  rename — warrants review. HTML attribute or ordering noise is invisible
+  because `_hrefs()` returns a frozenset.
 - new_path: path fresh-fetched but not matched by any policy rule. Needs a
   new rule or is a genuine AEMO addition.
 
@@ -39,7 +49,8 @@ HREF_RE = re.compile(rb'<A HREF="([^"]+)"', re.IGNORECASE)
 
 @dataclass(frozen=True)
 class AuditFinding:
-    kind: str  # "reclassify_up" | "reclassify_down" | "new_path"
+    kind: str  # "reclassify_up" | "reclassify_down" | "append_only_drift"
+    #            | "parent_index_drift" | "new_path"
     path: str
     current_class: str
     added_hrefs: int
@@ -111,6 +122,30 @@ def run_audit(
             )
             continue
 
+        if cls == "append_only" and removed > 0:
+            findings.append(
+                AuditFinding(
+                    kind="append_only_drift",
+                    path=url_path,
+                    current_class=cls,
+                    added_hrefs=added,
+                    removed_hrefs=removed,
+                )
+            )
+            continue
+
+        if cls == "parent_index" and changed > 0:
+            findings.append(
+                AuditFinding(
+                    kind="parent_index_drift",
+                    path=url_path,
+                    current_class=cls,
+                    added_hrefs=added,
+                    removed_hrefs=removed,
+                )
+            )
+            continue
+
     return findings
 
 
@@ -127,7 +162,13 @@ def format_report(findings: Iterable[AuditFinding]) -> str:
     groups: dict[str, list[AuditFinding]] = {}
     for f in findings:
         groups.setdefault(f.kind, []).append(f)
-    for kind in ("reclassify_up", "reclassify_down", "new_path"):
+    for kind in (
+        "reclassify_up",
+        "reclassify_down",
+        "append_only_drift",
+        "parent_index_drift",
+        "new_path",
+    ):
         items = groups.get(kind, [])
         if not items:
             continue

--- a/scripts/audit_policy.py
+++ b/scripts/audit_policy.py
@@ -146,7 +146,7 @@ def _load_fresh(fresh_dir: Path) -> dict[str, bytes]:
     out: dict[str, bytes] = {}
     for idx in fresh_dir.rglob("index.html"):
         rel = idx.parent.relative_to(fresh_dir).as_posix()
-        url = "/" + rel + "/" if rel else "/"
+        url = "/" + rel + "/" if rel and rel != "." else "/"
         out[url] = idx.read_bytes()
     return out
 

--- a/scripts/nemweb_download.py
+++ b/scripts/nemweb_download.py
@@ -24,6 +24,17 @@ Force-refresh all cached listings (bypass the cached-file shortcut so rolling
 
 Force-refresh a specific path only: delete its index.html on disk, then run
 the default walk or ``--gaps`` mode.
+
+Policy-driven refetch:
+    Load a freshness-policy YAML to skip ``static`` paths and limit
+    ``rolling`` / ``append_only`` fetches to the budget.  Can be combined
+    with ``--threads`` and ``--gaps`` for the canonical weekly-refresh
+    workflow:
+
+        POLICY=patterns/curated/freshness-policy.yaml
+        python3 scripts/nemweb_download.py --policy $POLICY [MAX_FETCHES]
+        python3 scripts/nemweb_download.py --threads 8 --gaps \
+            --policy $POLICY 10000
 """
 
 from __future__ import annotations

--- a/scripts/nemweb_download.py
+++ b/scripts/nemweb_download.py
@@ -141,7 +141,7 @@ class HREFExtractionShiftError(RuntimeError):
         self.after = after
 
 
-def save_listing(url_path: str, data: bytes) -> None:
+def save_listing(url_path: str, data: bytes) -> bool:
     """Content-aware write with template-shift guard.
 
     AEMO's IIS 8.5 server renders filesystem mtimes into directory listings,
@@ -150,13 +150,19 @@ def save_listing(url_path: str, data: bytes) -> None:
       1. Compares the HREF set from the cached file (if any) against the set
          extracted from the new bytes.
       2. If identical, skips the write (preserves mtime + byte identity, so
-         git stays clean for AEMO maintenance churn).
+         git stays clean for AEMO maintenance churn) and returns ``False``.
       3. If the new set is empty or drops >=50% vs. cached (and cached was
          non-empty), writes the new bytes for forensics but raises
          HREFExtractionShiftError so the workflow can open a P0.
-      4. Otherwise writes the new bytes.
+      4. Otherwise writes the new bytes and returns ``True``.
 
-    Empty-cache first-crawl falls through to an unconditional write.
+    Empty-cache first-crawl falls through to an unconditional write (``True``).
+
+    Returns:
+        ``True`` if bytes were written, ``False`` if the identical-content
+        short-circuit fired. Callers use this as the authoritative
+        fetch-vs-fetch-noop signal (don't infer from filesystem mtime — coarse
+        or cached filesystems can preserve mtime even on a real write).
     """
     p = OUT / url_path.lstrip("/")
     p.mkdir(parents=True, exist_ok=True)
@@ -175,8 +181,9 @@ def save_listing(url_path: str, data: bytes) -> None:
                 idx.write_bytes(data)  # forensic write, then raise
                 raise HREFExtractionShiftError(url_path, before=len(old), after=len(new))
             if old == new:
-                return
+                return False
     idx.write_bytes(data)
+    return True
 
 
 def extract_children(parent_path: str, data: bytes) -> list[str]:
@@ -317,12 +324,10 @@ def _process_one_for_test(
     data, status = throttled_fetch(url)
     if data is None or status != 200:
         return (path, "skip", [])
-    # Mark outcome as fetch_noop if content-aware write short-circuits
-    # by catching the early return in save_listing without mtime change.
-    before_mtime = cached.stat().st_mtime_ns if cached.is_file() else None
-    save_listing(path, data)
-    after_mtime = cached.stat().st_mtime_ns if cached.is_file() else None
-    outcome = "fetch_noop" if before_mtime == after_mtime else "fetch"
+    # Explicit wrote-bytes signal from save_listing avoids mtime inference
+    # that can be falsified on coarse-resolution or cached filesystems.
+    wrote = save_listing(path, data)
+    outcome = "fetch" if wrote else "fetch_noop"
     return (path, outcome, extract_children(path, data))
 
 
@@ -377,10 +382,11 @@ def walk(
         if data is None or status != 200:
             print(f"  skip {path} status={status}")
             return (path, "skip", [])
-        before_mtime = cached.stat().st_mtime_ns if cached.is_file() else None
-        save_listing(path, data)
-        after_mtime = cached.stat().st_mtime_ns if cached.is_file() else None
-        outcome = "fetch_noop" if before_mtime == after_mtime else "fetch"
+        # save_listing returns False when it short-circuits (cached bytes
+        # identical to fresh). Authoritative signal — avoids mtime inference
+        # that can be falsified on coarse-resolution filesystems.
+        wrote = save_listing(path, data)
+        outcome = "fetch" if wrote else "fetch_noop"
         return (path, outcome, extract_children(path, data))
 
     wave_n = 0

--- a/scripts/nemweb_download.py
+++ b/scripts/nemweb_download.py
@@ -321,7 +321,7 @@ def walk(
     max_fetches: int,
     force: bool = False,
     policy: object | None = None,
-) -> tuple[int, int, int]:
+) -> tuple[int, int, int, int]:
     """Wave-batched BFS. Each wave dispatches current frontier to a thread pool;
     children discovered become the next wave. Terminates when frontier is empty or
     max_fetches budget exhausted.
@@ -332,17 +332,23 @@ def walk(
     When ``policy`` is None and ``force`` is False, all cached paths are
     reused (legacy behaviour — matches original --gaps semantics).
 
-    Returns: (fetched, reused, skipped)
+    Returns: (fetched, fetched_noop, reused, skipped)
+      fetched      — paths where save_listing wrote new or changed content (mtime changed).
+      fetched_noop — paths fetched from the network but whose content was identical to the
+                     cached copy; save_listing's content-aware dedup short-circuited
+                     (mtime unchanged).
+      reused       — paths served entirely from the on-disk cache without a network fetch.
+      skipped      — paths skipped due to exhausted budget or non-200 response.
     """
     visited: set[str] = set()
-    fetched = reused = skipped = 0
+    fetched = fetched_noop = reused = skipped = 0
     frontier: list[str] = [s for s in seeds if s.endswith("/")]
 
     budget_lock = threading.Lock()
     budget = {"remaining": max_fetches}
 
     def process_one(path: str) -> tuple[str, str, list[str]]:
-        """Returns (path, outcome, children). Outcome: 'fetch' | 'reuse' | 'skip'."""
+        """Returns (path, outcome, children). Outcome: 'fetch' | 'fetch_noop' | 'reuse' | 'skip'."""
         cached = local_path(path)
         if cached.is_file() and not _should_refetch(path, force, policy):
             try:
@@ -360,8 +366,11 @@ def walk(
         if data is None or status != 200:
             print(f"  skip {path} status={status}")
             return (path, "skip", [])
+        before_mtime = cached.stat().st_mtime_ns if cached.is_file() else None
         save_listing(path, data)
-        return (path, "fetch", extract_children(path, data))
+        after_mtime = cached.stat().st_mtime_ns if cached.is_file() else None
+        outcome = "fetch_noop" if before_mtime == after_mtime else "fetch"
+        return (path, outcome, extract_children(path, data))
 
     wave_n = 0
     while frontier and budget["remaining"] > 0:
@@ -379,6 +388,9 @@ def walk(
                 if outcome == "fetch":
                     fetched += 1
                     print(f"  fetch[{fetched:4d}]  {path}")
+                elif outcome == "fetch_noop":
+                    fetched_noop += 1
+                    print(f"  fetch_noop[{fetched_noop:4d}]  {path}")
                 elif outcome == "reuse":
                     reused += 1
                 elif outcome == "skip":
@@ -386,7 +398,7 @@ def walk(
                 for c in children:
                     if c not in visited:
                         frontier.append(c)
-    return fetched, reused, skipped
+    return fetched, fetched_noop, reused, skipped
 
 
 # ----- CLI -----
@@ -425,12 +437,17 @@ def main(argv: list[str]) -> int:
     print(f"Seeds: {len(seeds)}  threads: {threads}  max_fetches: {max_fetches}  mode: {mode_str}")
 
     try:
-        fetched, reused, skipped = walk(seeds, threads, max_fetches, force=force, policy=policy)
+        fetched, fetched_noop, reused, skipped = walk(
+            seeds, threads, max_fetches, force=force, policy=policy
+        )
     except HREFExtractionShiftError as e:
         print(f"ERROR: {e}", file=sys.stderr)
         return 2
 
-    print(f"\nDone. fetched={fetched}  reused={reused}  skipped={skipped}  under {OUT}/")
+    print(
+        f"\nDone. fetched={fetched}  fetch_noop={fetched_noop}"
+        f"  reused={reused}  skipped={skipped}  under {OUT}/"
+    )
     return 0
 
 

--- a/scripts/nemweb_download.py
+++ b/scripts/nemweb_download.py
@@ -165,7 +165,7 @@ def save_listing(url_path: str, data: bytes) -> None:
         try:
             cached_bytes = idx.read_bytes()
         except OSError as e:
-            print(f"  warn: cache read failed for {url_path}: {e}", file=sys.stderr)
+            print(f"  WARN {url_path}: {type(e).__name__}: {e}", file=sys.stderr)
             cached_bytes = None
         if cached_bytes is not None:
             old = frozenset(m.group(1) for m in HREF_RE.finditer(cached_bytes))

--- a/scripts/nemweb_download.py
+++ b/scripts/nemweb_download.py
@@ -393,7 +393,10 @@ def walk(
             for path, outcome, children in ex.map(process_one, wave):
                 if outcome == "fetch":
                     fetched += 1
-                    print(f"  fetch     [{fetched:4d}]  {path}")
+                    # Keep `fetch[` byte-exact — weekly-refresh.yml greps literally
+                    # for it to compute TOTAL. Align the path column via trailing
+                    # spaces instead.
+                    print(f"  fetch[{fetched:4d}]       {path}")
                 elif outcome == "fetch_noop":
                     fetched_noop += 1
                     print(f"  fetch_noop[{fetched_noop:4d}]  {path}")

--- a/scripts/nemweb_download.py
+++ b/scripts/nemweb_download.py
@@ -387,7 +387,7 @@ def walk(
             for path, outcome, children in ex.map(process_one, wave):
                 if outcome == "fetch":
                     fetched += 1
-                    print(f"  fetch[{fetched:4d}]  {path}")
+                    print(f"  fetch     [{fetched:4d}]  {path}")
                 elif outcome == "fetch_noop":
                     fetched_noop += 1
                     print(f"  fetch_noop[{fetched_noop:4d}]  {path}")

--- a/scripts/nemweb_download.py
+++ b/scripts/nemweb_download.py
@@ -226,15 +226,35 @@ def parse_args(
         elif a == "--force":
             force = True
         elif a == "--policy":
+            if i + 1 >= len(argv):
+                raise SystemExit("--policy requires a value")
             policy_path = argv[i + 1]
+            if not policy_path:
+                raise SystemExit("--policy requires a non-empty path")
             i += 1
         elif a.startswith("--policy="):
             policy_path = a.split("=", 1)[1]
+            if not policy_path:
+                raise SystemExit("--policy requires a non-empty path")
         elif a == "--threads":
-            threads = int(argv[i + 1])
+            if i + 1 >= len(argv):
+                raise SystemExit("--threads requires a value")
+            raw = argv[i + 1]
+            try:
+                threads = int(raw)
+            except ValueError:
+                raise SystemExit(f"--threads must be a positive integer, got: {raw}") from None
+            if threads < 1:
+                raise SystemExit(f"--threads must be >= 1, got: {threads}")
             i += 1
         elif a.startswith("--threads="):
-            threads = int(a.split("=", 1)[1])
+            raw = a.split("=", 1)[1]
+            try:
+                threads = int(raw)
+            except ValueError:
+                raise SystemExit(f"--threads must be a positive integer, got: {raw}") from None
+            if threads < 1:
+                raise SystemExit(f"--threads must be >= 1, got: {threads}")
         elif a.isdigit():
             max_fetches = int(a)
         else:

--- a/scripts/nemweb_download.py
+++ b/scripts/nemweb_download.py
@@ -162,14 +162,20 @@ def save_listing(url_path: str, data: bytes) -> None:
     p.mkdir(parents=True, exist_ok=True)
     idx = p / "index.html"
     if idx.is_file():
-        old = frozenset(m.group(1) for m in HREF_RE.finditer(idx.read_bytes()))
-        new = frozenset(m.group(1) for m in HREF_RE.finditer(data))
-        template_shift = bool(old) and (not new or len(new) * 2 <= len(old))
-        if template_shift:
-            idx.write_bytes(data)  # forensic write, then raise
-            raise HREFExtractionShiftError(url_path, before=len(old), after=len(new))
-        if old == new:
-            return
+        try:
+            cached_bytes = idx.read_bytes()
+        except OSError as e:
+            print(f"  warn: cache read failed for {url_path}: {e}", file=sys.stderr)
+            cached_bytes = None
+        if cached_bytes is not None:
+            old = frozenset(m.group(1) for m in HREF_RE.finditer(cached_bytes))
+            new = frozenset(m.group(1) for m in HREF_RE.finditer(data))
+            template_shift = bool(old) and (not new or len(new) * 2 <= len(old))
+            if template_shift:
+                idx.write_bytes(data)  # forensic write, then raise
+                raise HREFExtractionShiftError(url_path, before=len(old), after=len(new))
+            if old == new:
+                return
     idx.write_bytes(data)
 
 

--- a/scripts/nemweb_download.py
+++ b/scripts/nemweb_download.py
@@ -266,6 +266,8 @@ def parse_args(
             i += 1
         elif a.startswith("--threads="):
             raw = a.split("=", 1)[1]
+            if not raw:
+                raise SystemExit("--threads requires a value")
             try:
                 threads = int(raw)
             except ValueError:

--- a/scripts/nemweb_download.py
+++ b/scripts/nemweb_download.py
@@ -243,7 +243,10 @@ def parse_args(
         elif a == "--force":
             force = True
         elif a == "--policy":
-            if i + 1 >= len(argv):
+            # Reject a following `--flag` so we don't silently consume a flag
+            # as the policy path (e.g. `--policy --gaps` → path = "--gaps" →
+            # confusing downstream PolicyLoadError).
+            if i + 1 >= len(argv) or argv[i + 1].startswith("--"):
                 raise SystemExit("--policy requires a value")
             policy_path = argv[i + 1]
             if not policy_path:
@@ -254,7 +257,7 @@ def parse_args(
             if not policy_path:
                 raise SystemExit("--policy requires a non-empty path")
         elif a == "--threads":
-            if i + 1 >= len(argv):
+            if i + 1 >= len(argv) or argv[i + 1].startswith("--"):
                 raise SystemExit("--threads requires a value")
             raw = argv[i + 1]
             try:

--- a/scripts/policy.py
+++ b/scripts/policy.py
@@ -58,7 +58,13 @@ class Policy:
         if not isinstance(raw["rules"], list) or not raw["rules"]:
             raise PolicyLoadError(f"policy 'rules' must be a non-empty list in {p}")
 
-        version = int(raw.get("version", 0))
+        raw_version = raw.get("version", 0)
+        try:
+            version = int(raw_version)
+        except (TypeError, ValueError) as e:
+            raise PolicyLoadError(
+                f"{p}: policy version must be an integer, got {raw_version!r}"
+            ) from e
         if version != 1:
             raise PolicyLoadError(f"{p}: unsupported policy version {version}, expected 1")
 

--- a/scripts/policy.py
+++ b/scripts/policy.py
@@ -59,12 +59,13 @@ class Policy:
             raise PolicyLoadError(f"policy 'rules' must be a non-empty list in {p}")
 
         raw_version = raw.get("version", 0)
-        try:
-            version = int(raw_version)
-        except (TypeError, ValueError) as e:
-            raise PolicyLoadError(
-                f"{p}: policy version must be an integer, got {raw_version!r}"
-            ) from e
+        # Strict type check: YAML can deliver bool, float, str, list, null —
+        # `int(...)` would silently coerce bool/float (int(True)=1, int(1.5)=1),
+        # letting malformed schemas pass as v1. Accept only Python int, and
+        # exclude bool explicitly since `isinstance(True, int)` is True.
+        if isinstance(raw_version, bool) or not isinstance(raw_version, int):
+            raise PolicyLoadError(f"{p}: policy version must be an integer, got {raw_version!r}")
+        version = raw_version
         if version != 1:
             raise PolicyLoadError(f"{p}: unsupported policy version {version}, expected 1")
 

--- a/scripts/policy.py
+++ b/scripts/policy.py
@@ -58,6 +58,10 @@ class Policy:
         if not isinstance(raw["rules"], list) or not raw["rules"]:
             raise PolicyLoadError(f"policy 'rules' must be a non-empty list in {p}")
 
+        version = int(raw.get("version", 0))
+        if version != 1:
+            raise PolicyLoadError(f"{p}: unsupported policy version {version}, expected 1")
+
         rules: list[_Rule] = []
         for i, entry in enumerate(raw["rules"]):
             if not isinstance(entry, dict):
@@ -75,7 +79,7 @@ class Policy:
             rules.append(_Rule(pattern=pattern, class_=cls_name, regex=_compile(pattern)))
 
         return cls(
-            version=int(raw.get("version", 0)),
+            version=version,
             last_reviewed=str(raw.get("last_reviewed", "")),
             reviewer=str(raw.get("reviewer", "")),
             rules=rules,

--- a/tests/test_audit_policy.py
+++ b/tests/test_audit_policy.py
@@ -83,6 +83,63 @@ def test_load_fresh_root_index_maps_to_slash(tmp_path):
     assert result["/"] == b"<pre></pre>"
 
 
+def test_append_only_path_with_removals_flags_drift(tmp_path):
+    # append_only guarantee: files only get added, never removed.
+    # Mirror has /a/ and /b/; fresh drops /b/ — removal violates the guarantee.
+    policy_path = _policy(tmp_path, "/Data_Append/**", "append_only")
+    mirror_root = tmp_path / "nemweb-mirror"
+    _mirror(tmp_path, "/Data_Append/x/", ["/a/", "/b/"])
+    fresh = {"/Data_Append/x/": b'<pre><A HREF="/a/">a</A></pre>'}
+    findings = run_audit(policy_path, mirror_root, fresh)
+    assert any(f.kind == "append_only_drift" and f.path == "/Data_Append/x/" for f in findings)
+
+
+def test_append_only_path_with_additions_only_is_clean(tmp_path):
+    # Additions are the EXPECTED behaviour for append_only — must not trigger a finding.
+    policy_path = _policy(tmp_path, "/Data_Append/**", "append_only")
+    mirror_root = tmp_path / "nemweb-mirror"
+    _mirror(tmp_path, "/Data_Append/x/", ["/a/"])
+    fresh = {"/Data_Append/x/": b'<pre><A HREF="/a/">a</A><A HREF="/b/">b</A></pre>'}
+    findings = run_audit(policy_path, mirror_root, fresh)
+    assert findings == []
+
+
+def test_append_only_path_no_change_is_clean(tmp_path):
+    # No change at all — completely clean, no finding.
+    policy_path = _policy(tmp_path, "/Data_Append/**", "append_only")
+    mirror_root = tmp_path / "nemweb-mirror"
+    _mirror(tmp_path, "/Data_Append/x/", ["/a/", "/b/"])
+    fresh = {"/Data_Append/x/": b'<pre><A HREF="/a/">a</A><A HREF="/b/">b</A></pre>'}
+    findings = run_audit(policy_path, mirror_root, fresh)
+    assert findings == []
+
+
+def test_parent_index_path_with_any_change_flags_drift(tmp_path):
+    # parent_index lists children; any set-level HREF change warrants review.
+    # Mirror has /child1/ and /child2/; fresh adds /child3/ — flag it.
+    policy_path = _policy(tmp_path, "/Reports/PARENT/**", "parent_index")
+    mirror_root = tmp_path / "nemweb-mirror"
+    _mirror(tmp_path, "/Reports/PARENT/", ["/child1/", "/child2/"])
+    fresh = {
+        "/Reports/PARENT/": (
+            b'<pre><A HREF="/child1/">a</A><A HREF="/child2/">b</A><A HREF="/child3/">c</A></pre>'
+        )
+    }
+    findings = run_audit(policy_path, mirror_root, fresh)
+    assert any(f.kind == "parent_index_drift" and f.path == "/Reports/PARENT/" for f in findings)
+
+
+def test_parent_index_path_no_change_is_clean(tmp_path):
+    # Identical cached and fresh HREF sets — no finding.
+    policy_path = _policy(tmp_path, "/Reports/PARENT/**", "parent_index")
+    mirror_root = tmp_path / "nemweb-mirror"
+    _mirror(tmp_path, "/Reports/PARENT/", ["/child1/", "/child2/"])
+    # Same hrefs, different HTML order — set equality must not trigger a finding.
+    fresh = {"/Reports/PARENT/": (b'<pre><A HREF="/child2/">b</A><A HREF="/child1/">a</A></pre>')}
+    findings = run_audit(policy_path, mirror_root, fresh)
+    assert findings == []
+
+
 def test_load_fresh_nested_index_maps_correctly(tmp_path):
     from scripts.audit_policy import _load_fresh
 

--- a/tests/test_audit_policy.py
+++ b/tests/test_audit_policy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from scripts.audit_policy import run_audit
+from scripts.audit_policy import AuditFinding, format_report, run_audit
 
 
 def _mirror(tmp_path: Path, path: str, hrefs: list[str]) -> Path:
@@ -154,3 +154,84 @@ def test_load_fresh_nested_index_maps_correctly(tmp_path):
         f"Expected '/Reports/CURRENT/' in result, got: {list(result.keys())}"
     )
     assert result["/Reports/CURRENT/"] == b"<pre>nested</pre>"
+
+
+def test_format_report_empty_findings_returns_clean_message():
+    result = format_report([])
+    assert result == "# Policy Audit — clean\n\nAll classified paths behaved as expected.\n"
+
+
+def test_format_report_multi_kind_groups_and_orders():
+    # Construct one finding of each kind, supplied in SCRAMBLED order.
+    findings = [
+        AuditFinding(
+            kind="parent_index_drift",
+            path="/p/",
+            current_class="parent_index",
+            added_hrefs=1,
+            removed_hrefs=0,
+        ),
+        AuditFinding(
+            kind="new_path",
+            path="/n/",
+            current_class="unclassified",
+            added_hrefs=2,
+            removed_hrefs=0,
+        ),
+        AuditFinding(
+            kind="reclassify_up", path="/u/", current_class="static", added_hrefs=3, removed_hrefs=0
+        ),
+        AuditFinding(
+            kind="append_only_drift",
+            path="/a/",
+            current_class="append_only",
+            added_hrefs=0,
+            removed_hrefs=1,
+        ),
+        AuditFinding(
+            kind="reclassify_down",
+            path="/d/",
+            current_class="rolling",
+            added_hrefs=0,
+            removed_hrefs=0,
+        ),
+    ]
+    result = format_report(findings)
+
+    # Top-level header must report 5 findings.
+    assert "5 findings." in result
+
+    # All 5 section headers must be present with count suffix (1).
+    assert "## reclassify_up (1)" in result
+    assert "## reclassify_down (1)" in result
+    assert "## append_only_drift (1)" in result
+    assert "## parent_index_drift (1)" in result
+    assert "## new_path (1)" in result
+
+    # Canonical order: reclassify_up < reclassify_down < append_only_drift
+    #                  < parent_index_drift < new_path — regardless of input order.
+    pos_up = result.index("## reclassify_up")
+    pos_down = result.index("## reclassify_down")
+    pos_ao = result.index("## append_only_drift")
+    pos_pi = result.index("## parent_index_drift")
+    pos_np = result.index("## new_path")
+    assert pos_up < pos_down < pos_ao < pos_pi < pos_np
+
+
+def test_format_report_skips_kinds_with_no_items():
+    # Only reclassify_up findings — the other 4 section headers must be absent.
+    findings = [
+        AuditFinding(
+            kind="reclassify_up", path="/u/", current_class="static", added_hrefs=1, removed_hrefs=0
+        ),
+        AuditFinding(
+            kind="reclassify_up", path="/v/", current_class="static", added_hrefs=2, removed_hrefs=0
+        ),
+    ]
+    result = format_report(findings)
+
+    assert "## reclassify_up (2)" in result
+    assert "## reclassify_down" not in result
+    assert "## append_only_drift" not in result
+    assert "## parent_index_drift" not in result
+    assert "## new_path" not in result

--- a/tests/test_audit_policy.py
+++ b/tests/test_audit_policy.py
@@ -66,3 +66,34 @@ def test_clean_audit_returns_no_findings(tmp_path):
     fresh = {"/Reports/CURRENT/x/": b'<pre><A HREF="/b/">b</A><A HREF="/c/">c</A></pre>'}
     findings = run_audit(policy_path, mirror_root, fresh)
     assert findings == []
+
+
+def test_load_fresh_root_index_maps_to_slash(tmp_path):
+    from scripts.audit_policy import _load_fresh
+
+    # Root-level index.html — fresh_dir itself contains the file.
+    root_idx = tmp_path / "index.html"
+    root_idx.write_bytes(b"<pre></pre>")
+
+    result = _load_fresh(tmp_path)
+
+    # Must produce "/" not "/./"
+    assert "/" in result, f"Expected key '/' in result, got: {list(result.keys())}"
+    assert "/./" not in result, f"Got wrong key '/./'; keys: {list(result.keys())}"
+    assert result["/"] == b"<pre></pre>"
+
+
+def test_load_fresh_nested_index_maps_correctly(tmp_path):
+    from scripts.audit_policy import _load_fresh
+
+    # Nested index.html — should produce /Reports/CURRENT/ (no regression).
+    nested = tmp_path / "Reports" / "CURRENT"
+    nested.mkdir(parents=True)
+    (nested / "index.html").write_bytes(b"<pre>nested</pre>")
+
+    result = _load_fresh(tmp_path)
+
+    assert "/Reports/CURRENT/" in result, (
+        f"Expected '/Reports/CURRENT/' in result, got: {list(result.keys())}"
+    )
+    assert result["/Reports/CURRENT/"] == b"<pre>nested</pre>"

--- a/tests/test_download_policy_walk.py
+++ b/tests/test_download_policy_walk.py
@@ -97,6 +97,91 @@ def test_process_one_unclassified_refetches(tmp_path: Path, monkeypatch) -> None
     fetch_mock.assert_called_once()
 
 
+# --- EXT-1: bounds-checking tests ---
+
+
+def test_parse_args_policy_missing_value() -> None:
+    """--policy with no following argument must raise SystemExit."""
+    import nemweb_download as mod
+    import pytest
+
+    with pytest.raises(SystemExit):
+        mod.parse_args(["--policy"])
+
+
+def test_parse_args_policy_empty_string() -> None:
+    """--policy "" (empty value) must raise SystemExit."""
+    import nemweb_download as mod
+    import pytest
+
+    with pytest.raises(SystemExit):
+        mod.parse_args(["--policy", ""])
+
+
+def test_parse_args_policy_equals_empty() -> None:
+    """--policy= (empty via = form) must raise SystemExit."""
+    import nemweb_download as mod
+    import pytest
+
+    with pytest.raises(SystemExit):
+        mod.parse_args(["--policy="])
+
+
+def test_parse_args_threads_missing_value() -> None:
+    """--threads with no following argument must raise SystemExit."""
+    import nemweb_download as mod
+    import pytest
+
+    with pytest.raises(SystemExit):
+        mod.parse_args(["--threads"])
+
+
+def test_parse_args_threads_non_integer() -> None:
+    """--threads abc must raise SystemExit with message about invalid integer."""
+    import nemweb_download as mod
+    import pytest
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod.parse_args(["--threads", "abc"])
+    assert "--threads" in str(exc_info.value)
+    assert "abc" in str(exc_info.value)
+
+
+def test_parse_args_threads_zero() -> None:
+    """--threads 0 must raise SystemExit (must be >= 1)."""
+    import nemweb_download as mod
+    import pytest
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod.parse_args(["--threads", "0"])
+    assert "--threads" in str(exc_info.value)
+    assert "0" in str(exc_info.value)
+
+
+def test_parse_args_threads_negative() -> None:
+    """--threads -5 must raise SystemExit (must be >= 1)."""
+    import nemweb_download as mod
+    import pytest
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod.parse_args(["--threads", "-5"])
+    assert "--threads" in str(exc_info.value)
+    assert "-5" in str(exc_info.value)
+
+
+def test_parse_args_happy_path_full_argv() -> None:
+    """Full happy-path argv must parse correctly (acceptance criterion 8)."""
+    import nemweb_download as mod
+
+    gaps, _force, policy_path, threads, max_fetches = mod.parse_args(
+        ["--policy", "foo.yaml", "--threads", "4", "--gaps", "5000"]
+    )
+    assert policy_path == "foo.yaml"
+    assert threads == 4
+    assert gaps is True
+    assert max_fetches == 5000
+
+
 def _policy(tmp_path: Path, pattern: str, cls: str) -> Path:
     p = tmp_path / "policy.yaml"
     p.write_text(

--- a/tests/test_download_policy_walk.py
+++ b/tests/test_download_policy_walk.py
@@ -189,3 +189,54 @@ def _policy(tmp_path: Path, pattern: str, cls: str) -> Path:
         f'  - pattern: "{pattern}"\n    class: {cls}\n'
     )
     return p
+
+
+# --- EXT-3: walk() fetch vs fetch_noop distinction ---
+
+
+def test_walk_emits_fetch_when_mtime_changes(tmp_path: Path, monkeypatch) -> None:
+    """walk() must return outcome 'fetch' when save_listing writes new content (mtime changes)."""
+    import nemweb_download as mod
+
+    monkeypatch.setattr(mod, "OUT", tmp_path)
+
+    seed = "/Reports/NEW/"
+    # No pre-existing cached file → mtime will change from None to something.
+    html = b"<pre></pre>"
+    with patch.object(mod, "throttled_fetch", return_value=(html, 200)):
+        result = mod.walk([seed], threads=1, max_fetches=10)
+
+    # New 4-tuple: (fetched, fetched_noop, reused, skipped)
+    assert len(result) == 4
+    fetched, fetched_noop, _reused, _skipped = result
+    assert fetched == 1
+    assert fetched_noop == 0
+
+
+def test_walk_emits_fetch_noop_when_mtime_unchanged(tmp_path: Path, monkeypatch) -> None:
+    """walk() must return 'fetch_noop' when save_listing short-circuits on identical content."""
+    import nemweb_download as mod
+
+    from scripts.policy import Policy
+
+    # Use a rolling policy so the walker refetches despite cache.
+    policy = Policy.load(_policy(tmp_path, "/Reports/**", "rolling"))
+    monkeypatch.setattr(mod, "OUT", tmp_path)
+
+    seed = "/Reports/CURRENT/x/"
+    # Empty listing — no child links, so no wave 2 fetches.
+    html = b"<pre></pre>"
+
+    # Pre-populate the cached file with the same bytes that the server will return.
+    cached = tmp_path / "Reports/CURRENT/x/index.html"
+    cached.parent.mkdir(parents=True)
+    cached.write_bytes(html)
+
+    with patch.object(mod, "throttled_fetch", return_value=(html, 200)):
+        result = mod.walk([seed], threads=1, max_fetches=10, policy=policy)
+
+    assert len(result) == 4
+    fetched, fetched_noop, _reused, _skipped = result
+    # Content-identical → save_listing short-circuits → mtime unchanged → fetch_noop
+    assert fetched_noop == 1
+    assert fetched == 0

--- a/tests/test_download_policy_walk.py
+++ b/tests/test_download_policy_walk.py
@@ -182,6 +182,48 @@ def test_parse_args_happy_path_full_argv() -> None:
     assert max_fetches == 5000
 
 
+def test_main_exits_2_on_policy_load_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    """main() must return 2 and print an 'ERROR: policy load failed:' prefix when
+    Policy.load raises PolicyLoadError (e.g. version != 1 triggers the POL-1 guard)."""
+    import nemweb_download as mod
+
+    bad_policy = tmp_path / "bad_policy.yaml"
+    bad_policy.write_text(
+        "version: 2\nlast_reviewed: 2026-04-21\nreviewer: t\nrules:\n"
+        '  - pattern: "/foo/**"\n    class: rolling\n'
+    )
+    monkeypatch.setattr(mod, "OUT", tmp_path)
+
+    result = mod.main(["--policy", str(bad_policy), "1"])
+
+    assert result == 2
+    captured = capsys.readouterr()
+    assert "ERROR: policy load failed:" in captured.err
+
+
+def test_main_exits_2_on_href_extraction_shift_error(tmp_path: Path, monkeypatch, capsys) -> None:
+    """main() must return 2 and print an 'ERROR:' prefix when walk() raises
+    HREFExtractionShiftError.  walk() is monkey-patched to raise directly since
+    triggering the real template-shift path requires a full HTTP mock + cached file
+    and is out of scope for this contract-pinning test."""
+    import nemweb_download as mod
+
+    monkeypatch.setattr(mod, "OUT", tmp_path)
+    monkeypatch.setattr(
+        mod,
+        "walk",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            mod.HREFExtractionShiftError("/test/path/", before=10, after=0)
+        ),
+    )
+
+    result = mod.main(["1"])
+
+    assert result == 2
+    captured = capsys.readouterr()
+    assert "ERROR:" in captured.err
+
+
 def _policy(tmp_path: Path, pattern: str, cls: str) -> Path:
     p = tmp_path / "policy.yaml"
     p.write_text(

--- a/tests/test_download_policy_walk.py
+++ b/tests/test_download_policy_walk.py
@@ -148,6 +148,31 @@ def test_parse_args_threads_equals_empty() -> None:
     assert "requires a value" in str(exc_info.value)
 
 
+def test_parse_args_policy_rejects_following_flag() -> None:
+    """`--policy --gaps` must fail with 'requires a value', not silently consume
+    `--gaps` as the policy path (which would produce a confusing downstream
+    'policy file not found: --gaps' error). PR #19 review.
+    """
+    import nemweb_download as mod
+    import pytest
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod.parse_args(["--policy", "--gaps"])
+    assert "requires a value" in str(exc_info.value)
+
+
+def test_parse_args_threads_rejects_following_flag() -> None:
+    """`--threads --gaps` must fail with 'requires a value', not fall through
+    to `int('--gaps')` → 'must be a positive integer'. PR #19 review.
+    """
+    import nemweb_download as mod
+    import pytest
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod.parse_args(["--threads", "--gaps"])
+    assert "requires a value" in str(exc_info.value)
+
+
 def test_parse_args_threads_non_integer() -> None:
     """--threads abc must raise SystemExit with message about invalid integer."""
     import nemweb_download as mod

--- a/tests/test_download_policy_walk.py
+++ b/tests/test_download_policy_walk.py
@@ -237,6 +237,7 @@ def test_walk_emits_fetch_noop_when_mtime_unchanged(tmp_path: Path, monkeypatch)
 
     assert len(result) == 4
     fetched, fetched_noop, _reused, _skipped = result
-    # Content-identical → save_listing short-circuits → mtime unchanged → fetch_noop
+    # save_listing's content-identical short-circuit keeps mtime unchanged;
+    # if that dedup is ever removed, this flips to fetched=1, fetched_noop=0.
     assert fetched_noop == 1
     assert fetched == 0

--- a/tests/test_download_policy_walk.py
+++ b/tests/test_download_policy_walk.py
@@ -136,6 +136,18 @@ def test_parse_args_threads_missing_value() -> None:
         mod.parse_args(["--threads"])
 
 
+def test_parse_args_threads_equals_empty() -> None:
+    """--threads= (explicit empty RHS) must fail with the same 'requires a value'
+    message used for bare --threads, not the 'positive integer' path. PR #19 review.
+    """
+    import nemweb_download as mod
+    import pytest
+
+    with pytest.raises(SystemExit) as exc_info:
+        mod.parse_args(["--threads="])
+    assert "requires a value" in str(exc_info.value)
+
+
 def test_parse_args_threads_non_integer() -> None:
     """--threads abc must raise SystemExit with message about invalid integer."""
     import nemweb_download as mod

--- a/tests/test_download_save_listing.py
+++ b/tests/test_download_save_listing.py
@@ -57,7 +57,7 @@ def test_writes_when_no_cached_file(tmp_path: Path, monkeypatch) -> None:
     assert (tmp_path / "Reports/CURRENT/x/index.html").read_bytes() == data
 
 
-def test_template_shift_raises_when_new_empty(tmp_path: Path, monkeypatch) -> None:
+def test_template_shift_triggers_at_50pct_via_lowercase_href(tmp_path: Path, monkeypatch) -> None:
     import nemweb_download as mod
 
     monkeypatch.setattr(mod, "OUT", tmp_path)
@@ -67,6 +67,22 @@ def test_template_shift_raises_when_new_empty(tmp_path: Path, monkeypatch) -> No
 
     # Refetched bytes contain no parseable <A HREF="..."> — template shift.
     refetched = b'<pre><a href="/a/">a</a></pre>'  # lowercase, regex misses
+    with pytest.raises(mod.HREFExtractionShiftError):
+        mod.save_listing("/Reports/CURRENT/x/", refetched)
+    # Forensic write: the bytes ARE saved even though the guard raised.
+    assert idx.read_bytes() == refetched
+
+
+def test_template_shift_raises_when_no_anchor_tags_at_all(tmp_path: Path, monkeypatch) -> None:
+    import nemweb_download as mod
+
+    monkeypatch.setattr(mod, "OUT", tmp_path)
+    idx = tmp_path / "Reports/CURRENT/x/index.html"
+    idx.parent.mkdir(parents=True)
+    idx.write_bytes(b'<pre><A HREF="/a/">a</A><A HREF="/b/">b</A></pre>')
+
+    # Refetched bytes contain NO anchor tags at all — genuinely zero HREFs.
+    refetched = b"<html><body>maintenance page</body></html>"
     with pytest.raises(mod.HREFExtractionShiftError):
         mod.save_listing("/Reports/CURRENT/x/", refetched)
     # Forensic write: the bytes ARE saved even though the guard raised.

--- a/tests/test_download_save_listing.py
+++ b/tests/test_download_save_listing.py
@@ -57,6 +57,40 @@ def test_writes_when_no_cached_file(tmp_path: Path, monkeypatch) -> None:
     assert (tmp_path / "Reports/CURRENT/x/index.html").read_bytes() == data
 
 
+def test_save_listing_returns_true_when_writes_occur(tmp_path: Path, monkeypatch) -> None:
+    """PR #19 review: save_listing returns explicit bool; True means bytes were
+    written (either first-crawl or content changed). Authoritative signal the
+    walker uses for fetch vs fetch_noop classification — avoids mtime inference.
+    """
+    import nemweb_download as mod
+
+    monkeypatch.setattr(mod, "OUT", tmp_path)
+    # Case A: cache miss → writes → True
+    wrote = mod.save_listing("/Reports/CURRENT/x/", b'<pre><A HREF="/a/">a</A></pre>')
+    assert wrote is True
+
+    # Case B: existing cache, HREFs changed → writes → True
+    wrote = mod.save_listing(
+        "/Reports/CURRENT/x/",
+        b'<pre><A HREF="/a/">a</A><A HREF="/b/">b</A></pre>',
+    )
+    assert wrote is True
+
+
+def test_save_listing_returns_false_on_identical_hrefs(tmp_path: Path, monkeypatch) -> None:
+    """PR #19 review: save_listing returns False when content-identical short-
+    circuit fires (HREF set unchanged). Pins the fetch_noop signal contract.
+    """
+    import nemweb_download as mod
+
+    monkeypatch.setattr(mod, "OUT", tmp_path)
+    # First write seeds the cache.
+    mod.save_listing("/Reports/CURRENT/x/", b'<pre><A HREF="/a/">a</A></pre>')
+    # Second call with identical HREF set (different surrounding bytes OK) → no write → False.
+    wrote = mod.save_listing("/Reports/CURRENT/x/", b'<pre>noise <A HREF="/a/">a</A></pre>')
+    assert wrote is False
+
+
 def test_template_shift_triggers_at_50pct_via_lowercase_href(tmp_path: Path, monkeypatch) -> None:
     import nemweb_download as mod
 

--- a/tests/test_download_save_listing.py
+++ b/tests/test_download_save_listing.py
@@ -125,3 +125,27 @@ def test_template_shift_does_not_trigger_on_small_drop(tmp_path: Path, monkeypat
     # Should NOT raise — a legitimate 40% rolloff in a rolling directory.
     mod.save_listing("/Reports/CURRENT/x/", refetched)
     assert idx.read_bytes() == refetched, "40% drop is within threshold; write should proceed"
+
+
+def test_save_listing_survives_osread_error(tmp_path: Path, monkeypatch) -> None:
+    """OSError from idx.read_bytes() is caught; new bytes are written unconditionally."""
+    import nemweb_download as mod
+
+    monkeypatch.setattr(mod, "OUT", tmp_path)
+    idx = tmp_path / "Reports/CURRENT/x/index.html"
+    idx.parent.mkdir(parents=True)
+    idx.write_bytes(b'<pre><A HREF="/old/">old</A></pre>')
+
+    # Simulate a filesystem hiccup: read_bytes raises OSError even though is_file() is True.
+    def _raise_oserror(self: Path) -> bytes:
+        raise OSError("simulated read failure")
+
+    monkeypatch.setattr(Path, "read_bytes", _raise_oserror)
+
+    new_data = b'<pre><A HREF="/a/">a</A></pre>'
+    # Must not raise — OSError should be swallowed and treated as cache-miss.
+    mod.save_listing("/Reports/CURRENT/x/", new_data)
+
+    # Restore read_bytes to verify disk contents.
+    monkeypatch.undo()
+    assert idx.read_bytes() == new_data, "new bytes must be written on cache-read failure"

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -196,6 +196,48 @@ def test_list_version_raises_policy_load_error(tmp_path: Path) -> None:
         )
 
 
+def test_bool_version_raises_policy_load_error(tmp_path: Path) -> None:
+    """PR #19 review: YAML `version: true` parses as Python True; int(True)==1
+    would silently pass the v1 guard. Strict isinstance check must reject.
+    """
+    with pytest.raises(PolicyLoadError, match="policy version must be an integer"):
+        Policy.load(
+            _write(
+                tmp_path,
+                "version: true\nlast_reviewed: 2026-04-20\nreviewer: x\nrules:\n"
+                '  - pattern: "/Reports/**"\n    class: rolling\n',
+            )
+        )
+
+
+def test_float_version_raises_policy_load_error(tmp_path: Path) -> None:
+    """PR #19 review: YAML `version: 1.5` parses as Python float; int(1.5)==1
+    would silently truncate past the v1 guard. Strict isinstance check must reject.
+    """
+    with pytest.raises(PolicyLoadError, match="policy version must be an integer"):
+        Policy.load(
+            _write(
+                tmp_path,
+                "version: 1.5\nlast_reviewed: 2026-04-20\nreviewer: x\nrules:\n"
+                '  - pattern: "/Reports/**"\n    class: rolling\n',
+            )
+        )
+
+
+def test_string_version_raises_policy_load_error(tmp_path: Path) -> None:
+    """Quoted-string version `version: "1"` is rejected by strict isinstance.
+    Canonical form is YAML int. Prevents schema-type drift.
+    """
+    with pytest.raises(PolicyLoadError, match="policy version must be an integer"):
+        Policy.load(
+            _write(
+                tmp_path,
+                'version: "1"\nlast_reviewed: 2026-04-20\nreviewer: x\nrules:\n'
+                '  - pattern: "/Reports/**"\n    class: rolling\n',
+            )
+        )
+
+
 def test_data_archive_bare_path_is_parent_index_not_static(tmp_path: Path) -> None:
     """Pins the fix for the /Data_Archive/** shadow bug.
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -170,6 +170,32 @@ def test_missing_version_raises(tmp_path: Path) -> None:
         )
 
 
+def test_non_integer_version_raises_policy_load_error(tmp_path: Path) -> None:
+    """PR #19 review: version: 'v1' (or any non-castable) must produce PolicyLoadError,
+    not raw ValueError — callers only handle PolicyLoadError for exit-2 behaviour.
+    """
+    with pytest.raises(PolicyLoadError, match="policy version must be an integer"):
+        Policy.load(
+            _write(
+                tmp_path,
+                "version: v1\nlast_reviewed: 2026-04-20\nreviewer: x\nrules:\n"
+                '  - pattern: "/Reports/**"\n    class: rolling\n',
+            )
+        )
+
+
+def test_list_version_raises_policy_load_error(tmp_path: Path) -> None:
+    """PR #19 review: version as a list (YAML sequence) must map to PolicyLoadError."""
+    with pytest.raises(PolicyLoadError, match="policy version must be an integer"):
+        Policy.load(
+            _write(
+                tmp_path,
+                "version: [1]\nlast_reviewed: 2026-04-20\nreviewer: x\nrules:\n"
+                '  - pattern: "/Reports/**"\n    class: rolling\n',
+            )
+        )
+
+
 def test_data_archive_bare_path_is_parent_index_not_static(tmp_path: Path) -> None:
     """Pins the fix for the /Data_Archive/** shadow bug.
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -137,6 +137,39 @@ def test_pattern_without_leading_slash_raises(tmp_path: Path) -> None:
         )
 
 
+def test_version_0_raises(tmp_path: Path) -> None:
+    with pytest.raises(PolicyLoadError, match="unsupported policy version 0"):
+        Policy.load(
+            _write(
+                tmp_path,
+                "version: 0\nlast_reviewed: 2026-04-20\nreviewer: x\nrules:\n"
+                '  - pattern: "/Reports/**"\n    class: rolling\n',
+            )
+        )
+
+
+def test_version_2_raises(tmp_path: Path) -> None:
+    with pytest.raises(PolicyLoadError, match="unsupported policy version 2"):
+        Policy.load(
+            _write(
+                tmp_path,
+                "version: 2\nlast_reviewed: 2026-04-20\nreviewer: x\nrules:\n"
+                '  - pattern: "/Reports/**"\n    class: rolling\n',
+            )
+        )
+
+
+def test_missing_version_raises(tmp_path: Path) -> None:
+    with pytest.raises(PolicyLoadError, match="unsupported policy version 0"):
+        Policy.load(
+            _write(
+                tmp_path,
+                "last_reviewed: 2026-04-20\nreviewer: x\nrules:\n"
+                '  - pattern: "/Reports/**"\n    class: rolling\n',
+            )
+        )
+
+
 def test_data_archive_bare_path_is_parent_index_not_static(tmp_path: Path) -> None:
     """Pins the fix for the /Data_Archive/** shadow bug.
 


### PR DESCRIPTION
## Summary

Batched hygiene pass across policy loader, audit, CLI ergonomics, test coverage, and release workflow — 12 items from issue #11, one PR, ahead of v0.2 feature work. CAT-1 intentionally deferred (user-demand gated).

- **Policy/audit fixes:** `Policy.load` rejects unsupported schema versions (POL-1); `run_audit` surfaces drift findings for `append_only` + `parent_index` classes (POL-2); `_load_fresh` root index maps to `/` not `/./` (POL-3).
- **`nemweb_download.py` ergonomics:** argv bounds-check for `--policy`/`--threads` (EXT-1); `--policy` documented in module docstring (EXT-2); walker distinguishes `fetch` vs `fetch_noop` in outcomes + logs (EXT-3); `save_listing` survives `OSError` on cached-file read (EXT-4).
- **Test coverage:** template-shift test renamed + truly-zero-HREF companion (TEST-1); `main()` exit-2 pinned on `PolicyLoadError` + `HREFExtractionShiftError` (TEST-2); `format_report` empty + multi-kind + skip-empty paths covered (TEST-3).
- **Workflows:** dropped unused `crawl_attempted.outputs.ts` from `weekly-refresh.yml` (WF-1); `release.yml` auto-populates GitHub Release on tag push, idempotent on re-run (WF-2).

## Scope

| Bucket | Items | Files touched |
|--------|-------|---------------|
| POL-* | POL-1, POL-2, POL-3 | `scripts/policy.py`, `scripts/audit_policy.py`, `tests/test_policy.py`, `tests/test_audit_policy.py` |
| EXT-* | EXT-1..4 | `scripts/nemweb_download.py`, `tests/test_download_policy_walk.py`, `tests/test_download_save_listing.py` |
| TEST-* | TEST-1, TEST-2, TEST-3 | `tests/test_download_save_listing.py`, `tests/test_download_policy_walk.py`, `tests/test_audit_policy.py` |
| WF-* | WF-1, WF-2 | `.github/workflows/weekly-refresh.yml`, `.github/workflows/release.yml` |
| **Deferred** | **CAT-1** | user-demand gated, intentionally skipped |

`src/nem_catalog/` untouched — no user-visible SDK change.

## Commits

15 atomic commits (12 primary items + 3 follow-up style/ci fixes from code review):

```
70b829a ci(release): make gh release create idempotent on workflow re-run (WF-2 follow-up)
d107d67 ci(release): auto-populate GitHub Release on tag push (WF-2)
752ded0 ci(workflow): drop unused crawl_attempted.outputs.ts from weekly-refresh (WF-1)
42d8fbd test(audit): cover format_report empty + multi-kind + skip-empty paths (TEST-3)
7ff882a test(cli): pin nemweb_download main() exit-2 on PolicyLoadError + HREFExtractionShiftError (TEST-2)
16017e1 test(cli): rename template-shift test + add zero-anchor-tag companion (TEST-1)
2895ef5 style(cli): align save_listing OSError warn format with file conventions (EXT-4 follow-up)
a287f94 fix(cli): save_listing survives OSError on cached-file read (EXT-4)
eaa356d style(cli): column-align fetch/fetch_noop logs + anchor noop test (EXT-3 follow-up)
91635f1 feat(cli): walker distinguishes fetch vs fetch_noop outcomes (EXT-3)
090823c docs(cli): document --policy flag in nemweb_download module docstring (EXT-2)
095bbe9 feat(cli): bounds-check --policy and --threads in nemweb_download (EXT-1)
6095ae3 feat(audit): surface append_only and parent_index drift findings (POL-2)
5a08b39 feat(policy): reject unsupported policy schema versions (POL-1)
842b1ca fix(audit): _load_fresh root index produces / not /./ (POL-3)
```

Diffstat: **+557 / -26 across 9 files** (3 scripts, 4 tests, 2 workflows).

## Notable design decisions

- **POL-2 strict semantics:** `append_only_drift` fires on any HREF removal (class guarantee: files accumulate, never disappear). `parent_index_drift` fires on any set-level change in the parent listing (cosmetic HTML reorder is invisible because `_hrefs()` returns a `frozenset`).
- **EXT-3 mirrors the test harness pattern:** the mtime-compare logic in `_process_one_for_test` was the reference; production `process_one` now uses the same shape. `walk()`'s return shape grew from 3-tuple to 4-tuple `(fetched, fetched_noop, reused, skipped)`.
- **`fetch[` log-line byte-preserved** (ops log-scanner safety), `fetch_noop[` column-aligned alongside it.
- **WF-2 idempotency:** first run creates, subsequent runs no-op with a friendly log line — so a partial-failure re-run (PyPI succeeds, release create fails) doesn't trigger a spurious P0 issue.

## Out of scope — logged for later

- **CAT-1** (`catalog.policy_version` field at catalog root) — user-demand gated per issue #11, not yet signalled.
- **Dead `LAST_CRAWL_ATTEMPTED_AT` env var** in `weekly-refresh.yml` — WF-1 narrowly removed the unused output; the entire `Record crawl-attempted timestamp` step may be dead and can be removed in a future cleanup.
- **Duplicated `_policy` test helper** across `tests/test_download_policy_walk.py` and `tests/test_audit_policy.py` — 6-line helpers, byte-identical. Extracting to `conftest.py` is worth it when a 3rd test file needs them; deferred.

## Test plan

- [x] `uv run pytest` — 149 passed (+27 new tests vs master's 122)
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run mypy --strict` — clean (src/ scope)
- [x] YAML parse both workflows
- [x] TDD red-green-commit discipline enforced per item (except pure-docs EXT-2 and YAML WF-1/WF-2)
- [x] Each item reviewed for spec compliance + code quality independently
- [x] Final full-branch integration review: "Ready to PR"
- [ ] Next `policy-audit.yml` scheduled run (2026-05-01 00:00 UTC) exercises POL-1/POL-2/POL-3 against the real mirror — issue #14 tracks the v0.2 pre-tag acceptance gate
- [ ] Next `v*` tag push verifies WF-2 auto-populates the GitHub Releases page

Closes #11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic GitHub Release creation for pushed tags
  * Policy-driven refetch mode with explicit noop-detection reported

* **Bug Fixes**
  * Root listing URL generation corrected
  * More resilient handling when reading cached files; unchanged fetches now reported separately

* **Chores**
  * Stricter CLI argument validation with clearer error messages
  * Improved crawl counting to include noop fetches

* **Tests**
  * Expanded coverage for policy loading, download/refetch behavior, listing persistence, and reporting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->